### PR TITLE
ENH: Add a multiscale_spatial_image_version entry to .zattrs

### DIFF
--- a/multiscale_spatial_image.py
+++ b/multiscale_spatial_image.py
@@ -126,7 +126,7 @@ class MultiscaleSpatialImage(DataTree):
             )
 
         # NGFF v0.4 metadata
-        ngff_metadata = {"multiscales": multiscales}
+        ngff_metadata = {"multiscales": multiscales, "multiscaleSpatialImageVersion": 1}
         self.ds.attrs = ngff_metadata
 
         super().to_zarr(store, **kwargs)


### PR DESCRIPTION
As a hint for readers that the dataset level has a `.zattrs` which may have `direction`, `long-name`, etc. this PR adds an entry in the top level `.zattrs`.  Results in this:
```
{
    "multiscaleSpatialImageVersion": 1,
    "multiscales": [
        {
            "@type": "ngff:Image",
```
Related #41 
