### PR TITLE
BUG: Fix downsampled scale dim order with dask-image resampling

### DIFF
--- a/multiscale_spatial_image/to_multiscale/_support.py
+++ b/multiscale_spatial_image/to_multiscale/_support.py
@@ -2,10 +2,10 @@ _spatial_dims = {"x", "y", "z"}
 
 def _dim_scale_factors(dims, scale_factor):
     if isinstance(scale_factor, int):
-        dim = {dim: scale_factor for dim in _spatial_dims.intersection(dims)}
+        result_scale_factors = {dim: scale_factor for dim in _spatial_dims.intersection(dims)}
     else:
-        dim = scale_factor
-    return dim
+        result_scale_factors = scale_factor
+    return result_scale_factors
 
 
 def _align_chunks(current_input, default_chunks, dim_factors):

--- a/multiscale_spatial_image/to_multiscale/itk_image_to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/itk_image_to_multiscale.py
@@ -53,7 +53,8 @@ def itk_image_to_multiscale(
     scale = {image_dims[i]: s for (i, s) in enumerate(image.GetSpacing())}
     translation = {image_dims[i]: s for (i, s) in enumerate(image.GetOrigin())}
 
-    spatial_image = to_spatial_image(image_da,
+    spatial_image = to_spatial_image(image_da.data,
+                                     dims=image_da.dims,
                                      scale=scale,
                                      translation=translation,
                                      name=name,


### PR DESCRIPTION
The dim order was reversed from the input data / scale 0.