### PR TITLE
raise error for invalid scale factors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ examples/chelsea.zarr/
 .ipynb_checkpoints
 examples/sub-I46_ses-SPIM_sample-BrocaAreaS01_stain-GAD67_chunk-00_SPIM*
 examples/dask-worker-space/
+
+__pycache__

--- a/multiscale_spatial_image/to_multiscale/to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/to_multiscale.py
@@ -86,7 +86,6 @@ def to_multiscale(
     
     # check for valid scale factors
     current_shape = {d:s for (s, d) in zip(image.shape, image.dims) if d != "c"}
-    print(current_shape)
 
     for scale_factor in scale_factors:
         if isinstance(scale_factor, dict):

--- a/multiscale_spatial_image/to_multiscale/to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/to_multiscale.py
@@ -73,6 +73,16 @@ def to_multiscale(
     out_chunks = chunks
     if out_chunks is None:
         out_chunks = default_chunks
+    
+    # check for valid scale factors
+    current_shape = np.array(
+        [s for (s, d) in zip(image.shape, image.dims) if d != "c"], dtype=np.float_
+    )
+
+    for sf in scale_factors:
+        current_shape /= float(sf)
+        if current_shape.min() < 1:
+            raise ValueError(f"Scale factor {sf} is incompatible with image shape {image.shape}.")
 
     current_input = image.chunk(out_chunks)
     # https://github.com/pydata/xarray/issues/5219

--- a/multiscale_spatial_image/to_multiscale/to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/to_multiscale.py
@@ -75,14 +75,17 @@ def to_multiscale(
         out_chunks = default_chunks
     
     # check for valid scale factors
-    current_shape = np.array(
-        [s for (s, d) in zip(image.shape, image.dims) if d != "c"], dtype=np.float_
-    )
+    current_shape = {d:s for (s, d) in zip(image.shape, image.dims) if d != "c"}
+    print(current_shape)
 
-    for sf in scale_factors:
-        current_shape /= float(sf)
-        if current_shape.min() < 1:
-            raise ValueError(f"Scale factor {sf} is incompatible with image shape {image.shape}.")
+    for scale_factor in scale_factors:
+        if isinstance(scale_factor, dict):
+            current_shape = {k: (current_shape[k] / s) for (k, s) in scale_factor.items()}
+        elif isinstance(scale_factor, int):
+            current_shape = {k: (s / scale_factor) for (k, s) in current_shape.items()}
+        for k,v in current_shape.items():
+            if v < 1:
+                raise ValueError(f"Scale factor {scale_factor} is incompatible with image shape {image.shape} along dimension {k}.")
 
     current_input = image.chunk(out_chunks)
     # https://github.com/pydata/xarray/issues/5219

--- a/multiscale_spatial_image/to_multiscale/to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/to_multiscale.py
@@ -85,7 +85,7 @@ def to_multiscale(
         out_chunks = default_chunks
     
     # check for valid scale factors
-    current_shape = {d:s for (s, d) in zip(image.shape, image.dims) if d != "c"}
+    current_shape = {d:s for (d, s) in zip(image.dims, image.shape) if d not in {"t", "c"}}
 
     for scale_factor in scale_factors:
         if isinstance(scale_factor, dict):
@@ -94,7 +94,7 @@ def to_multiscale(
             current_shape = {k: (s / scale_factor) for (k, s) in current_shape.items()}
         for k,v in current_shape.items():
             if v < 1:
-                raise ValueError(f"Scale factor {scale_factor} is incompatible with image shape {image.shape} along dimension {k}.")
+                raise ValueError(f"Scale factor {scale_factor} is incompatible with image shape {image.shape} along dimension `{k}`.")
 
     current_input = image.chunk(out_chunks)
     # https://github.com/pydata/xarray/issues/5219

--- a/test/test_to_multiscale.py
+++ b/test/test_to_multiscale.py
@@ -1,19 +1,19 @@
 import xarray as xr
 import pytest
-import re
-from multiscale_spatial_image import Methods, to_multiscale 
+from multiscale_spatial_image import Methods, to_multiscale
 
 from ._data import input_images
+
 
 def test_base_scale(input_images):
     image = input_images["cthead1"]
 
     multiscale = to_multiscale(image, [])
-    xr.testing.assert_equal(image, multiscale['scale0'].ds["cthead1"])
+    xr.testing.assert_equal(image, multiscale["scale0"].ds["cthead1"])
 
     image = input_images["small_head"]
     multiscale = to_multiscale(image, [])
-    xr.testing.assert_equal(image, multiscale['scale0'].ds["small_head"])
+    xr.testing.assert_equal(image, multiscale["scale0"].ds["small_head"])
 
     with pytest.raises(ValueError):
         to_multiscale(image, scale_factors=[500])

--- a/test/test_to_multiscale.py
+++ b/test/test_to_multiscale.py
@@ -1,5 +1,6 @@
 import xarray as xr
-
+import pytest
+import re
 from multiscale_spatial_image import Methods, to_multiscale 
 
 from ._data import input_images
@@ -13,3 +14,6 @@ def test_base_scale(input_images):
     image = input_images["small_head"]
     multiscale = to_multiscale(image, [])
     xr.testing.assert_equal(image, multiscale['scale0'].ds["small_head"])
+
+    with pytest.raises(ValueError):
+        to_multiscale(image, scale_factors=[500])

--- a/test/test_to_multiscale.py
+++ b/test/test_to_multiscale.py
@@ -1,6 +1,6 @@
 import xarray as xr
 import pytest
-from multiscale_spatial_image import Methods, to_multiscale
+from multiscale_spatial_image import to_multiscale
 
 from ._data import input_images
 

--- a/test/test_to_multiscale.py
+++ b/test/test_to_multiscale.py
@@ -17,3 +17,4 @@ def test_base_scale(input_images):
 
     with pytest.raises(ValueError):
         to_multiscale(image, scale_factors=[500])
+        to_multiscale(image, scale_factors=[{"x": 10}, {"x": 500, "y": 10}])


### PR DESCRIPTION
cross ref from here https://github.com/scverse/spatialdata/issues/110

@thewtex  here a `ValueError` is raised but please let me know if you think a logging or just a warning should be raised instead.

I tried to make dask fail with invalid chunk sizes as described here: https://github.com/scverse/spatialdata/issues/110#issuecomment-1399616374 I *think* I understood what you mean but I didn't manage to make a reprex with couple of resizing methods (`Methods.XARRAY_COARSEN` and `Methods.DASK_IMAGE_NEAREST`). Basically even if I pass larger-than-axes chunks the method would still bound to the max value for that dimension, I'll try a bit more later. On a separate note, should this check happen at *inferred* chunk sizes from the passed `chunks` and 1image.shape` or should it happen after the resizing already completed (before returning the DataTree). Thank you!