### PR TITLE
list downsampling methods in docstring of `to_multiscale`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ examples/chelsea.zarr/
 .ipynb_checkpoints
 examples/sub-I46_ses-SPIM_sample-BrocaAreaS01_stain-GAD67_chunk-00_SPIM*
 examples/dask-worker-space/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/

--- a/multiscale_spatial_image/_docs.py
+++ b/multiscale_spatial_image/_docs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Any, Callable
+
+
+def inject_docs(**kwargs: Any) -> Callable[..., Any]:
+    # taken from scanpy
+    def decorator(obj: Any) -> Any:
+        obj.__doc__ = dedent(obj.__doc__).format(**kwargs)
+        return obj
+
+    def decorator2(obj: Any) -> Any:
+        obj.__doc__ = dedent(kwargs["__doc__"])
+        return obj
+
+    if isinstance(kwargs.get("__doc__", None), str) and len(kwargs) == 1:
+        return decorator2
+
+    return decorator

--- a/multiscale_spatial_image/_docs.py
+++ b/multiscale_spatial_image/_docs.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from textwrap import dedent
 from typing import Any, Callable
 

--- a/multiscale_spatial_image/_docs.py
+++ b/multiscale_spatial_image/_docs.py
@@ -10,11 +10,4 @@ def inject_docs(**kwargs: Any) -> Callable[..., Any]:
         obj.__doc__ = dedent(obj.__doc__).format(**kwargs)
         return obj
 
-    def decorator2(obj: Any) -> Any:
-        obj.__doc__ = dedent(kwargs["__doc__"])
-        return obj
-
-    if isinstance(kwargs.get("__doc__", None), str) and len(kwargs) == 1:
-        return decorator2
-
     return decorator

--- a/multiscale_spatial_image/to_multiscale/to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/to_multiscale.py
@@ -11,6 +11,7 @@ from ..multiscale_spatial_image import MultiscaleSpatialImage
 from ._xarray import _downsample_xarray_coarsen
 from ._itk import _downsample_itk_bin_shrink, _downsample_itk_gaussian, _downsample_itk_label
 from ._dask_image import _downsample_dask_image
+from .._docs import inject_docs
 
 class Methods(Enum):
     XARRAY_COARSEN = "xarray_coarsen"
@@ -21,7 +22,7 @@ class Methods(Enum):
     DASK_IMAGE_MODE = "dask_image_mode"
     DASK_IMAGE_NEAREST = "dask_image_nearest"
 
-
+@inject_docs(m=Methods)
 def to_multiscale(
     image: SpatialImage,
     scale_factors: Sequence[Union[Dict[str, int], int]],
@@ -35,7 +36,8 @@ def to_multiscale(
         ]
     ] = None,
 ) -> MultiscaleSpatialImage:
-    """Generate a multiscale representation of a spatial image.
+    """\
+    Generate a multiscale representation of a spatial image.
 
     Parameters
     ----------
@@ -46,10 +48,18 @@ def to_multiscale(
     scale_factors : int per scale or dict of spatial dimension int's per scale
         Integer scale factors to apply uniformly across all spatial dimension or
         along individual spatial dimensions.
-        Examples: [2, 2] or [{'x': 2, 'y': 4 }, {'x': 5, 'y': 10}]
+        Examples: [2, 2] or [{{'x': 2, 'y': 4 }}, {{'x': 5, 'y': 10}}]
 
     method : multiscale_spatial_image.Methods, optional
-        Method to reduce the input image.
+        Method to reduce the input image. Available methods are the following:
+
+        - `{m.XARRAY_COARSEN.value!r}` - Use xarray coarsen to downsample the image.
+        - `{m.ITK_BIN_SHRINK.value!r}` - Use ITK BinShrinkImageFilter to downsample the image.
+        - `{m.ITK_GAUSSIAN.value!r}` - Use ITK GaussianImageFilter to downsample the image.
+        - `{m.ITK_LABEL_GAUSSIAN.value!r}` - Use ITK LabelGaussianImageFilter to downsample the image.
+        - `{m.DASK_IMAGE_GAUSSIAN.value!r}` - Use dask-image gaussian_filter to downsample the image.
+        - `{m.DASK_IMAGE_MODE.value!r}` - Use dask-image mode_filter to downsample the image.
+        - `{m.DASK_IMAGE_NEAREST.value!r}` - Use dask-image zoom to downsample the image.
 
     chunks : xarray Dask array chunking specification, optional
         Specify the chunking used in each output scale.


### PR DESCRIPTION
This PR improves docstrings to explicitly list downsampling methods used to build the multiscale spatial image. This is the result.

```
    method : multiscale_spatial_image.Methods, optional
        Method to reduce the input image. Available methods are the following:
    
        - `'xarray_coarsen'` - Use xarray coarsen to downsample the image.
        - `'itk_bin_shrink'` - Use ITK BinShrinkImageFilter to downsample the image.
        - `'itk_gaussian'` - Use ITK GaussianImageFilter to downsample the image.
        - `'itk_label_gaussian'` - Use ITK LabelGaussianImageFilter to downsample the image.
        - `'dask_image_gaussian'` - Use dask-image gaussian_filter to downsample the image.
        - `'dask_image_mode'` - Use dask-image mode_filter to downsample the image.
        - `'dask_image_nearest'` - Use dask-image zoom to downsample the image.
```

thought it'd be a useful feature for users, please disregard if not in scope. 
