### PR TITLE
adjust to xarray datatree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ examples/sub-I46_ses-SPIM_sample-BrocaAreaS01_stain-GAD67_chunk-00_SPIM*
 examples/dask-worker-space/
 .pixi/
 examples/Cell_Colony.zarr/
+.idea/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/multiscale_spatial_image/multiscale_spatial_image.py
+++ b/multiscale_spatial_image/multiscale_spatial_image.py
@@ -1,11 +1,10 @@
 from typing import Union
 
-from datatree import DataTree
+from xarray import DataTree, register_datatree_accessor
 import numpy as np
 from collections.abc import MutableMapping
 from pathlib import Path
 from zarr.storage import BaseStore
-from datatree import register_datatree_accessor
 
 
 @register_datatree_accessor("msi")

--- a/multiscale_spatial_image/to_multiscale/itk_image_to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/itk_image_to_multiscale.py
@@ -3,7 +3,7 @@ from typing import Union, Sequence, List, Optional, Dict, Mapping, Any, Tuple
 from spatial_image import to_spatial_image
 
 from .to_multiscale import to_multiscale, Methods
-from datatree import DataTree
+from xarray import DataTree
 
 
 def itk_image_to_multiscale(

--- a/multiscale_spatial_image/to_multiscale/to_multiscale.py
+++ b/multiscale_spatial_image/to_multiscale/to_multiscale.py
@@ -4,7 +4,7 @@ from enum import Enum
 from spatial_image import SpatialImage  # type: ignore
 
 
-from datatree import DataTree
+from xarray import DataTree
 
 from ._xarray import _downsample_xarray_coarsen
 from ._itk import (
@@ -184,6 +184,6 @@ def to_multiscale(
             label="mode",
         )
 
-    multiscale = DataTree.from_dict(d=data_objects)
+    multiscale = DataTree.from_dict(data_objects)
 
     return multiscale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
     "dask",
     "python-dateutil",
     "spatial_image>=0.2.1",
-    "xarray",
-    "xarray-datatree>=0.0.5",
+    "xarray>=2024.10.0",
     "zarr",
 ]
 

--- a/test/_data.py
+++ b/test/_data.py
@@ -4,7 +4,6 @@ import pytest
 import pooch
 from zarr.storage import DirectoryStore
 import xarray as xr
-from datatree import open_datatree
 
 test_data_ipfs_cid = "bafybeiaskr5fxg6rbcwlxl6ibzqhubdleacenrpbnymc6oblwoi7ceqzta"
 test_data_sha256 = "507dd779cba007c46ea68a5fe8865cabd5d8a7e00816470faae9195d1f1c3cd1"
@@ -58,7 +57,7 @@ def verify_against_baseline(dataset_name, baseline_name, multiscale):
         test_data_dir / f"baseline/{dataset_name}/{baseline_name}",
         dimension_separator="/",
     )
-    dt = open_datatree(store, engine="zarr", mode="r")
+    dt = xr.open_datatree(store, engine="zarr", mode="r")
     xr.testing.assert_equal(dt.ds, multiscale.ds)
     for scale in multiscale.children:
         xr.testing.assert_equal(dt[scale].ds, multiscale[scale].ds)

--- a/test/test_ngff_validation.py
+++ b/test/test_ngff_validation.py
@@ -5,7 +5,7 @@ import urllib3
 from referencing import Registry, Resource
 from jsonschema import Draft202012Validator
 
-from datatree import DataTree
+from xarray import DataTree
 
 from multiscale_spatial_image import to_multiscale, MultiscaleSpatialImage
 from spatial_image import to_spatial_image


### PR DESCRIPTION
Xarray has archived the datatree repository, the new import `from xarray import datatree` and `from_dict` only accepts positional arguments from now on. Opening this PR in draft mode for now as I am still checking on the changes in `SpatialData`.