### PR TITLE
drop python.3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pixi.lock
+++ b/pixi.lock
@@ -5324,9 +5324,9 @@ packages:
   requires_python: '>=3.7'
 - kind: pypi
   name: multiscale-spatial-image
-  version: 1.0.1
+  version: 2.0.0
   path: .
-  sha256: 1212b0ca4248a330d4ea49bdd21de8f8e70e3fe627d2b4dd2b9897760bd811df
+  sha256: e2b3803080e5a8d162c70da12307451ac21d609cbd5deb6ee5306a1f60c03064
   requires_dist:
   - dask
   - numpy
@@ -5350,7 +5350,7 @@ packages:
   - pytest ; extra == 'test'
   - pytest-mypy ; extra == 'test'
   - urllib3 ; extra == 'test'
-  requires_python: '>=3.10'
+  requires_python: <3.13,>=3.10
   editable: true
 - kind: pypi
   name: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: 3.13',
    ]
 keywords = [
     "itk",
@@ -31,7 +30,7 @@ keywords = [
 ]
 dynamic = ["version"]
 
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "numpy",
     "dask",


### PR DESCRIPTION
We can't currently install xarray-dataclasses in python 3.13. Trying to install in a bare python 3.13 environment gives the following:

```
└─ xarray-dataclasses is installable with the potential options
   ├─ xarray-dataclasses [1.6.0|1.7.0] would require
   │  └─ numpy >=1.22,<2.0.0a0  with the potential options
   │     ├─ numpy [1.21.3|1.21.4|...|1.26.4] would require
   │     │  └─ python >=3.10,<3.11.0a0 , which can be installed;
   │     ├─ numpy [1.21.0|1.21.1|...|1.24.4] would require
   │     │  └─ python >=3.8,<3.9.0a0 , which can be installed;
   │     ├─ numpy [1.21.0|1.21.1|...|1.26.4] would require
   │     │  └─ python >=3.9,<3.10.0a0 , which can be installed;
   │     ├─ numpy [1.23.4|1.23.5|...|1.26.4] would require
   │     │  └─ python >=3.11,<3.12.0a0 , which can be installed;
   │     ├─ numpy 1.26.0 would require
   │     │  └─ python >=3.12.0rc3,<3.13.0a0  with the potential options
   │     │     ├─ python [3.12.0|3.12.1|...|3.12.7], which can be installed;
   │     │     └─ python 3.12.0rc3 would require
   │     │        └─ _python_rc, which does not exist (perhaps a missing channel);
   │     └─ numpy [1.26.2|1.26.3|1.26.4] would require
   │        └─ python >=3.12,<3.13.0a0 , which can be installed;
   └─ xarray-dataclasses 1.7.0 would require
      └─ xarray >=2022.3,<2024.0  with the potential options
         ├─ xarray [2022.10.0|2022.11.0|...|2023.1.0] would require
         │  └─ pandas [>=1.2,<2a0 |>=1.3,<2a0 ] with the potential options
         │     ├─ pandas [1.1.0|1.1.1|...|1.3.5] would require
         │     │  └─ python >=3.7,<3.8.0a0 , which can be installed;
         │     ├─ pandas [1.1.0|1.1.1|...|1.5.3] would require
         │     │  └─ python >=3.8,<3.9.0a0 , which can be installed;
         │     ├─ pandas [1.1.3|1.1.4|...|1.5.3] would require
         │     │  └─ python >=3.9,<3.10.0a0 , which can be installed;
         │     ├─ pandas [1.3.4|1.3.5|...|1.5.3] would require
         │     │  └─ python >=3.10,<3.11.0a0 , which can be installed;
         │     └─ pandas [1.5.1|1.5.2|1.5.3] would require
         │        └─ python >=3.11,<3.12.0a0 , which can be installed;
         ├─ xarray [2022.3.0|2022.6.0] would require
         │  └─ pandas >=1.1,<2a0  with the potential options
         │     ├─ pandas [1.1.0|1.1.1|...|1.1.5] would require
         │     │  └─ python >=3.6,<3.7.0a0 , which can be installed;
         │     ├─ pandas [1.1.0|1.1.1|...|1.3.5], which can be installed (as previously explained);
         │     ├─ pandas [1.1.0|1.1.1|...|1.5.3], which can be installed (as previously explained);
         │     ├─ pandas [1.1.3|1.1.4|...|1.5.3], which can be installed (as previously explained);
         │     ├─ pandas [1.3.4|1.3.5|...|1.5.3], which can be installed (as previously explained);
         │     └─ pandas [1.5.1|1.5.2|1.5.3], which can be installed (as previously explained);
         ├─ xarray [2023.10.0|2023.2.0|...|2023.9.0] would require
         │  └─ numpy >=1.21,<2.0a0  with the potential options
         │     ├─ numpy [1.21.3|1.21.4|...|1.26.4], which can be installed (as previously explained);
         │     ├─ numpy [1.21.0|1.21.1|...|1.24.4], which can be installed (as previously explained);
         │     ├─ numpy [1.21.0|1.21.1|...|1.26.4], which can be installed (as previously explained);
         │     ├─ numpy [1.23.4|1.23.5|...|1.26.4], which can be installed (as previously explained);
         │     ├─ numpy 1.26.0, which can be installed (as previously explained);
         │     ├─ numpy [1.26.2|1.26.3|1.26.4], which can be installed (as previously explained);
         │     └─ numpy [1.21.0|1.21.1|...|1.21.6] would require
         │        └─ python >=3.7,<3.8.0a0 , which can be installed;
         └─ xarray [2023.10.0|2023.10.1|2023.11.0|2023.12.0|2023.8.0] would require
            └─ numpy >=1.22,<2.0a0 , which can be installed (as previously explained).
```

Since the `spatial-image` dependency requires `xarray-dataclasses` this PR drops python 3.13 support for now. This should be no problem given that the previous version did not support python 3.13 either.