### PR TITLE
update readme example to new xarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ An [Xarray] [spatial-image] [DataArray]. Spatial metadata can also be passed
 during construction.
 
 ```
-<xarray.SpatialImage 'image' (y: 128, x: 128)>
-array([[114,  47, 215, ..., 245,  14, 175],
-       [ 94, 186, 112, ...,  42,  96,  30],
-       [133, 170, 193, ..., 176,  47,   8],
+<xarray.DataArray 'image' (y: 128, x: 128)> Size: 16kB
+array([[166, 225, 182, ..., 118, 153,  82],
+       [194,  64,  15, ...,  50,  45, 146],
+       [232,  41,  44, ..., 148, 245, 170],
        ...,
-       [202, 218, 237, ...,  19, 108, 135],
-       [ 99,  94, 207, ..., 233,  83, 112],
-       [157, 110, 186, ..., 142, 153,  42]], dtype=uint8)
+       [ 99,  94,   7, ..., 136, 205,  30],
+       [ 52, 244, 229, ..., 108,  45,  58],
+       [ 72, 122, 212, ..., 183,  73, 188]], dtype=uint8)
 Coordinates:
-  * y        (y) float64 0.0 1.0 2.0 3.0 4.0 ... 123.0 124.0 125.0 126.0 127.0
-  * x        (x) float64 0.0 1.0 2.0 3.0 4.0 ... 123.0 124.0 125.0 126.0 127.0
+  * y        (y) float64 1kB 0.0 1.0 2.0 3.0 4.0 ... 124.0 125.0 126.0 127.0
+  * x        (x) float64 1kB 0.0 1.0 2.0 3.0 4.0 ... 124.0 125.0 126.0 127.0
 ```
 
 ```python
@@ -59,28 +59,29 @@ print(multiscale)
 A chunked [Dask] Array MultiscaleSpatialImage [Xarray] [Datatree].
 
 ```
-DataTree('multiscales', parent=None)
-├── DataTree('scale0')
-│   Dimensions:  (y: 128, x: 128)
-│   Coordinates:
-│     * y        (y) float64 0.0 1.0 2.0 3.0 4.0 ... 123.0 124.0 125.0 126.0 127.0
-│     * x        (x) float64 0.0 1.0 2.0 3.0 4.0 ... 123.0 124.0 125.0 126.0 127.0
-│   Data variables:
-│       image    (y, x) uint8 dask.array<chunksize=(128, 128), meta=np.ndarray>
-├── DataTree('scale1')
-│   Dimensions:  (y: 64, x: 64)
-│   Coordinates:
-│     * y        (y) float64 0.5 2.5 4.5 6.5 8.5 ... 118.5 120.5 122.5 124.5 126.5
-│     * x        (x) float64 0.5 2.5 4.5 6.5 8.5 ... 118.5 120.5 122.5 124.5 126.5
-│   Data variables:
-│       image    (y, x) uint8 dask.array<chunksize=(64, 64), meta=np.ndarray>
-└── DataTree('scale2')
-    Dimensions:  (y: 16, x: 16)
-    Coordinates:
-      * y        (y) float64 3.5 11.5 19.5 27.5 35.5 ... 91.5 99.5 107.5 115.5 123.5
-      * x        (x) float64 3.5 11.5 19.5 27.5 35.5 ... 91.5 99.5 107.5 115.5 123.5
-    Data variables:
-        image    (y, x) uint8 dask.array<chunksize=(16, 16), meta=np.ndarray>
+<xarray.DataTree>
+Group: /
+├── Group: /scale0
+│       Dimensions:  (y: 128, x: 128)
+│       Coordinates:
+│         * y        (y) float64 1kB 0.0 1.0 2.0 3.0 4.0 ... 124.0 125.0 126.0 127.0
+│         * x        (x) float64 1kB 0.0 1.0 2.0 3.0 4.0 ... 124.0 125.0 126.0 127.0
+│       Data variables:
+│           image    (y, x) uint8 16kB dask.array<chunksize=(128, 128), meta=np.ndarray>
+├── Group: /scale1
+│       Dimensions:  (y: 64, x: 64)
+│       Coordinates:
+│         * y        (y) float64 512B 0.5 2.5 4.5 6.5 8.5 ... 120.5 122.5 124.5 126.5
+│         * x        (x) float64 512B 0.5 2.5 4.5 6.5 8.5 ... 120.5 122.5 124.5 126.5
+│       Data variables:
+│           image    (y, x) uint8 4kB dask.array<chunksize=(64, 64), meta=np.ndarray>
+└── Group: /scale2
+        Dimensions:  (y: 16, x: 16)
+        Coordinates:
+          * y        (y) float64 128B 3.5 11.5 19.5 27.5 35.5 ... 99.5 107.5 115.5 123.5
+          * x        (x) float64 128B 3.5 11.5 19.5 27.5 35.5 ... 99.5 107.5 115.5 123.5
+        Data variables:
+            image    (y, x) uint8 256B dask.array<chunksize=(16, 16), meta=np.ndarray>
 ```
 
 Map a function over datasets while skipping nodes that do not contain dimensions


### PR DESCRIPTION
The readme example shows the old string representation of `DataTree`. This PR updates the readme to show the new representation.