### PR TITLE
Add python 3.13 in pyproject and workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
 ]
 dynamic = ["version"]
 
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "dask",


### PR DESCRIPTION
Reintroduce Python 3.13 support.
Closes #104 

The CI will fail because at the moment I cannot regenerate the lock file (see my comment here https://github.com/spatial-image/multiscale-spatial-image/pull/105#issuecomment-2649134616).