### PR TITLE
Require zarr v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "python-dateutil",
     "spatial_image>=0.2.1",
     "xarray>=2024.10.0",
-    "zarr",
+    "zarr>=2,<3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Currently, the module won't even import using zarr v3