### PR TITLE
zarr 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,6 @@ method and `assign_coords`, equivalent to `xr.Dataset` `assign_coords` method.
 Store as an Open Microscopy Environment-Next Generation File Format ([OME-NGFF])
 / [netCDF] [Zarr] store.
 
-It is highly recommended to use `dimension_separator='/'` in the construction of
-the Zarr stores.
-
-```python
-store = zarr.storage.DirectoryStore('multiscale.zarr', dimension_separator='/')
-multiscale.to_zarr(store)
-```
-
 **Note**: The API is under development, and it may change until 1.0.0 is
 released. We mean it :-).
 

--- a/multiscale_spatial_image/multiscale_spatial_image.py
+++ b/multiscale_spatial_image/multiscale_spatial_image.py
@@ -4,12 +4,18 @@ from xarray import DataTree, register_datatree_accessor
 import numpy as np
 from collections.abc import MutableMapping, Hashable
 from pathlib import Path
-from zarr.storage import BaseStore
+import zarr.storage
 from multiscale_spatial_image.operations import (
     transpose,
     reindex_data_arrays,
     assign_coords,
 )
+
+# Zarr Python 3
+if hasattr(zarr.storage, "StoreLike"):
+    StoreLike = zarr.storage.StoreLike
+else:
+    StoreLike = Union[MutableMapping, str, Path, zarr.storage.BaseStore]
 
 
 @register_datatree_accessor("msi")
@@ -33,7 +39,7 @@ class MultiscaleSpatialImage:
 
     def to_zarr(
         self,
-        store: Union[MutableMapping, str, Path, BaseStore],
+        store: StoreLike,
         mode: str = "w",
         encoding=None,
         **kwargs,
@@ -43,7 +49,7 @@ class MultiscaleSpatialImage:
 
         Metadata is added according the OME-NGFF standard.
 
-        store : MutableMapping, str or Path, or zarr.storage.BaseStore
+        store : StoreLike
             Store or path to directory in file system
         mode : {{"w", "w-", "a", "r+", None}, default: "w"
             Persistence mode: “w” means create (overwrite if exists); “w-” means create (fail if exists);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ description = "Generate a multiscale, chunked, multi-dimensional spatial image d
 authors = [{name = "Matt McCormick", email = "matt@mmmccormick.com"}]
 readme = "README.md"
 license.file = "LICENSE"
-home-page = "https://github.com/spatial-image/multiscale-spatial-image"
 classifiers = [
    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/test/test_ngff_validation.py
+++ b/test/test_ngff_validation.py
@@ -29,7 +29,7 @@ def load_schema(version: str = "0.4", strict: bool = False) -> Dict:
 
 
 def check_valid_ngff(multiscale: DataTree):
-    store = zarr.storage.MemoryStore(dimension_separator="/")
+    store = zarr.storage.MemoryStore()
     assert isinstance(multiscale.msi, MultiscaleSpatialImage)
     multiscale.msi.to_zarr(store, compute=True)
     zarr.convenience.consolidate_metadata(store)


### PR DESCRIPTION
- COMP: Zarr Python 3 StoreLike support
- COMP: Use LocalStore for Zarr Python 3
- COMP: Remove dimension_deparator arg to MemoryStore
- Remove home-page from pyproject.toml
