### PR TITLE
New publishing workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,46 @@ jobs:
         uses: mikepenz/action-junit-report@v2
         with:
           report_paths: "junit/test-results*.xml"
+
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/multiscale_spatial_image/
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ examples/dask-worker-space/
 .pixi/
 examples/Cell_Colony.zarr/
 .idea/
+_version.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -251,19 +251,9 @@ We use the standard [GitHub flow].
 
 This section is relevant only for maintainers.
 
-1. Pull `git`'s `main` branch.
-2. `pixi install -a`
-3. `pixi run pre-commit-install`
-4. `pixi run -e test test`
-5. `pixi shell`
-6. `hatch version <new-version>`
-7. `git add .`
-8. `git commit -m "ENH: Bump version to <version>"`
-9. `hatch build`
-10. `hatch publish`
-11. `git push upstream main`
-12. Create a new tag and Release via the GitHub UI. Auto-generate release notes
-    and add additional notes as needed.
+Create a new tag and Release via the GitHub UI. Auto-generate release notes and
+add additional notes as needed. The version number is automatically updated via
+[hatch-vcs](https://hatch.pypa.io/latest/plugins/build/hooks/vcs/).
 
 [spatial-image]: https://github.com/spatial-image/spatial-image
 [Xarray]: https://xarray.pydata.org/en/stable/

--- a/multiscale_spatial_image/__about__.py
+++ b/multiscale_spatial_image/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2022-present NumFOCUS <info@numfocus.org>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "2.0.3"

--- a/multiscale_spatial_image/__init__.py
+++ b/multiscale_spatial_image/__init__.py
@@ -8,10 +8,8 @@ __all__ = [
     "to_multiscale",
     "itk_image_to_multiscale",
     "skip_non_dimension_nodes",
-    "__version__",
 ]
 
-from .__about__ import __version__
 from .multiscale_spatial_image import MultiscaleSpatialImage
 from .to_multiscale import Methods, to_multiscale, itk_image_to_multiscale
 from .utils import skip_non_dimension_nodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -76,7 +76,10 @@ notebooks = [
 line-length = 88
 
 [tool.hatch.version]
-path = "multiscale_spatial_image/__about__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "multiscale_spatial_image/_version.py"
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]


### PR DESCRIPTION
Hi @thewtex ,

had some issues with the publishing workflow (Pypi has [deprecated](https://blog.pypi.org/posts/2024-01-01-2fa-enforced/) user/password auth for upload a while ago). I switched to trusted publishing for some projects a while ago. If configured correctly on your Pypi end, this should make the publishing process much easier.

1. Create a new git tag
2. Publish release on gh
3. Done